### PR TITLE
Fix dispatch page param typing

### DIFF
--- a/app/(tenant)/[orgId]/dispatch/[userId]/page.tsx
+++ b/app/(tenant)/[orgId]/dispatch/[userId]/page.tsx
@@ -3,8 +3,12 @@ import { DispatchSkeleton } from "@/components/dispatch/dispatch-skeleton"
 import { LoadCard } from "@/components/dispatch/load-card";
 import { listLoadsByOrg, getAvailableDriversForLoad, getAvailableVehiclesForLoad } from "@/lib/fetchers/dispatchFetchers"
 
-export default async function DispatchPage({ params }: { params: { orgId: string; userId: string } }) {
-  const { orgId } = params
+export default async function DispatchPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; userId: string }>
+}) {
+  const { orgId } = await params
   if (!orgId) {
     return <div className="text-red-400 p-8">Organization not found.</div>
   }


### PR DESCRIPTION
## Summary
- adjust route params type in dispatch board page for Next.js 15

## Testing
- `npm run build` *(fails: CLERK_WEBHOOK_SECRET is not set)*

------
https://chatgpt.com/codex/tasks/task_e_6840d092bcdc83278909edfdf3d5e439