### PR TITLE
Fix load update action and replace color utilities

### DIFF
--- a/app/(auth)/error.tsx
+++ b/app/(auth)/error.tsx
@@ -1,11 +1,11 @@
-"use client"
+"use client";
 
-import React from "react"
-import Image from "next/image"
+import React from "react";
+import Image from "next/image";
 
 export default function Error() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-zinc-900">
+    <div className="flex items-center justify-center min-h-screen bg-background">
       <div className="flex flex-col items-center space-y-6">
         <Image
           src="/white_logo.png"
@@ -15,20 +15,20 @@ export default function Error() {
           className="h-16 w-auto mb-2"
           priority
         />
-        <span className="text-zinc-100 text-lg font-medium">
+        <span className="text-foreground text-lg font-medium">
           Oops! Something went wrong.
         </span>
-        <span className="text-zinc-400 text-base text-center max-w-md">
+        <span className="text-muted-foreground text-base text-center max-w-md">
           We couldn't load this tenant page. Please try refreshing, or contact
           support if the problem persists.
         </span>
         <button
           onClick={() => window.location.reload()}
-          className="px-4 py-2 bg-blue-500 text-white rounded-md shadow-md hover:bg-blue-800 transition-all duration-200"
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-md shadow-md hover:bg-primary/90 transition-all duration-200"
         >
           Try again
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/features/dashboard/recent-alerts-widget.tsx
+++ b/features/dashboard/recent-alerts-widget.tsx
@@ -24,7 +24,7 @@ export default async function RecentAlertsWidget() {
       alerts = result.data.map((a: any) => ({
         id: a.id,
         message: a.message,
-        severity: a.severity as Alert['severity'],
+        severity: a.severity as Alert["severity"],
         timestamp: a.timestamp,
       }));
     }
@@ -32,42 +32,58 @@ export default async function RecentAlertsWidget() {
     alerts = [];
   }
 
-  const getSeverityColor = (severity: Alert['severity']) => {
+  const getSeverityColor = (severity: Alert["severity"]) => {
     switch (severity) {
-      case 'high': return 'bg-red-500';
-      case 'medium': return 'bg-yellow-500';
-      case 'low': return 'bg-blue-500';
-      default: return 'bg-gray-500';
+      case "high":
+        return "bg-destructive";
+      case "medium":
+        return "bg-warning";
+      case "low":
+        return "bg-primary";
+      default:
+        return "bg-muted";
     }
   };
 
   return (
-    <div className="bg-black border border-gray-200 p-6 rounded-lg shadow-lg">
+    <div className="bg-background border border-border p-6 rounded-lg shadow-lg">
       <div className="flex items-center gap-2 mb-6">
-        <div className="bg-red-500 p-1.5 rounded">
-          <AlertTriangle className="h-4 w-4 text-white" />
+        <div className="bg-destructive p-1.5 rounded">
+          <AlertTriangle className="h-4 w-4 text-destructive-foreground" />
         </div>
-        <h2 className="text-lg font-semibold text-white">Recent Alerts</h2>
+        <h2 className="text-lg font-semibold text-foreground">Recent Alerts</h2>
       </div>
       {alerts.length === 0 ? (
-        <p className="text-gray-400">No recent alerts.</p>
+        <p className="text-muted-foreground">No recent alerts.</p>
       ) : (
         <div className="space-y-4">
           {alerts.map((alert) => (
-            <div key={alert.id} className="flex items-start justify-between gap-3">
+            <div
+              key={alert.id}
+              className="flex items-start justify-between gap-3"
+            >
               <div className="flex items-start gap-3 flex-1">
-                <div className={`w-2 h-2 rounded-full mt-2 ${getSeverityColor(alert.severity)}`} />
+                <div
+                  className={`w-2 h-2 rounded-full mt-2 ${getSeverityColor(alert.severity)}`}
+                />
                 <div className="flex-1">
-                  <p className="text-sm text-gray-200 leading-relaxed">{alert.message}</p>
+                  <p className="text-sm text-foreground leading-relaxed">
+                    {alert.message}
+                  </p>
                 </div>
               </div>
-              <div className="flex items-center gap-1 text-xs text-gray-400 flex-shrink-0">
+              <div className="flex items-center gap-1 text-xs text-muted-foreground flex-shrink-0">
                 <Clock className="h-3 w-3" />
-                <span>{alert.timestamp ? new Date(alert.timestamp).toLocaleTimeString() : ""}</span>
+                <span>
+                  {alert.timestamp
+                    ? new Date(alert.timestamp).toLocaleTimeString()
+                    : ""}
+                </span>
               </div>
             </div>
           ))}
         </div>
-      )}    </div>
+      )}{" "}
+    </div>
   );
 }

--- a/features/dashboard/todays-schedule-widget.tsx
+++ b/features/dashboard/todays-schedule-widget.tsx
@@ -31,41 +31,58 @@ export default async function TodaysScheduleWidget() {
 
   const getTimePeriodIcon = (timePeriod: string) => {
     switch (timePeriod) {
-      case 'Morning': return <Sun className="h-4 w-4 text-yellow-400" />;
-      case 'Afternoon': return <Sunset className="h-4 w-4 text-orange-400" />;
-      case 'Evening': return <Moon className="h-4 w-4 text-blue-400" />;
-      default: return <Calendar className="h-4 w-4 text-gray-400" />;
+      case "Morning":
+        return <Sun className="h-4 w-4 text-warning" />;
+      case "Afternoon":
+        return <Sunset className="h-4 w-4 text-accent" />;
+      case "Evening":
+        return <Moon className="h-4 w-4 text-primary" />;
+      default:
+        return <Calendar className="h-4 w-4 text-muted-foreground" />;
     }
   };
 
   const getTimePeriodColor = (timePeriod: string) => {
     switch (timePeriod) {
-      case 'Morning': return 'text-yellow-400';
-      case 'Afternoon': return 'text-orange-400';
-      case 'Evening': return 'text-blue-400';
-      default: return 'text-gray-400';
+      case "Morning":
+        return "text-warning";
+      case "Afternoon":
+        return "text-accent";
+      case "Evening":
+        return "text-primary";
+      default:
+        return "text-muted-foreground";
     }
   };
 
   return (
-    <div className="bg-black border border-gray-200 p-6 rounded-lg shadow-lg">
+    <div className="bg-background border border-border p-6 rounded-lg shadow-lg">
       <div className="flex items-center gap-2 mb-6">
-        <div className="bg-blue-500 p-1.5 rounded">
-          <Calendar className="h-4 w-4 text-white" />
+        <div className="bg-primary p-1.5 rounded">
+          <Calendar className="h-4 w-4 text-primary-foreground" />
         </div>
-        <h2 className="text-lg font-semibold text-white">Today's Schedule</h2>
+        <h2 className="text-lg font-semibold text-foreground">
+          Today's Schedule
+        </h2>
       </div>
       {scheduleItems.length === 0 ? (
-        <p className="text-gray-400">No items scheduled for today.</p>
+        <p className="text-muted-foreground">No items scheduled for today.</p>
       ) : (
         <div className="space-y-4">
           {scheduleItems.map((item) => (
-            <div key={item.id} className="flex items-center justify-between gap-3">
+            <div
+              key={item.id}
+              className="flex items-center justify-between gap-3"
+            >
               <div className="flex items-center gap-3 flex-1">
                 {getTimePeriodIcon(item.timePeriod)}
-                <span className="text-sm text-gray-200">{item.description}</span>
+                <span className="text-sm text-foreground">
+                  {item.description}
+                </span>
               </div>
-              <span className={`text-xs font-medium ${getTimePeriodColor(item.timePeriod)}`}>
+              <span
+                className={`text-xs font-medium ${getTimePeriodColor(item.timePeriod)}`}
+              >
                 {item.timePeriod}
               </span>
             </div>

--- a/lib/actions/loadActions.ts
+++ b/lib/actions/loadActions.ts
@@ -1,86 +1,138 @@
+"use server";
 
-'use server';
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/lib/database/db";
+import { revalidatePath } from "next/cache";
+import type { CreateLoadInput, UpdateLoadInput } from "@/schemas/dispatch";
+import { updateLoadSchema } from "@/schemas/dispatch";
 
-import { auth } from '@clerk/nextjs/server';
-import { db } from '@/lib/database/db';
-import { revalidatePath } from 'next/cache';
-import type { CreateLoadInput, UpdateLoadInput } from '@/schemas/dispatch';
-
-
-
+/**
+ * Update an existing load with the provided fields.
+ *
+ * @param id - The load identifier to update.
+ * @param data - Partial load data from the dispatch form.
+ * @returns Result with the updated load or an error message.
+ */
 export async function updateLoadAction(id: string, data: UpdateLoadInput) {
   try {
     const { userId, orgId } = await auth();
-    
+
     if (!userId || !orgId) {
-      return { success: false, error: 'Unauthorized' };
+      return { success: false, error: "Unauthorized" };
     }
 
+    const validated = updateLoadSchema.parse(data);
+    const {
+      rate,
+      customer,
+      origin,
+      destination,
+      driver,
+      vehicle,
+      trailer,
+      ...rest
+    } = validated;
+
+    const dbData: any = {
+      ...rest,
+      updatedAt: new Date(),
+    };
+
+    if (typeof rate !== "undefined") dbData.rate = rate;
+
+    if (customer && typeof customer === "object") {
+      dbData.customerName = customer.name ?? null;
+      dbData.customerContact = customer.contactName ?? null;
+      dbData.customerPhone = customer.phone ?? null;
+      dbData.customerEmail = customer.email ?? null;
+    }
+
+    if (origin && typeof origin === "object") {
+      dbData.originAddress = origin.address ?? null;
+      dbData.originCity = origin.city ?? null;
+      dbData.originState = origin.state ?? null;
+      dbData.originZip = origin.zip ?? null;
+      dbData.originLat = origin.latitude ?? null;
+      dbData.originLng = origin.longitude ?? null;
+    }
+
+    if (destination && typeof destination === "object") {
+      dbData.destinationAddress = destination.address ?? null;
+      dbData.destinationCity = destination.city ?? null;
+      dbData.destinationState = destination.state ?? null;
+      dbData.destinationZip = destination.zip ?? null;
+      dbData.destinationLat = destination.latitude ?? null;
+      dbData.destinationLng = destination.longitude ?? null;
+    }
+
+    if (driver && typeof driver === "object" && driver.id)
+      dbData.driverId = driver.id;
+    if (vehicle && typeof vehicle === "object" && vehicle.id)
+      dbData.vehicleId = vehicle.id;
+    if (trailer && typeof trailer === "object" && trailer.id)
+      dbData.trailerId = trailer.id;
+
     const load = await db.load.update({
-      where: { 
+      where: {
         id,
         organizationId: orgId,
       },
-      data: {
-        
-        updatedAt: new Date(),
-      },
+      data: dbData,
     });
 
-    revalidatePath('/[orgId]/dispatch', 'page');
+    revalidatePath("/[orgId]/dispatch", "page");
     return { success: true, data: load };
   } catch (error) {
-    console.error('Error updating load:', error);
-    return { success: false, error: 'Failed to update load' };
+    console.error("Error updating load:", error);
+    return { success: false, error: "Failed to update load" };
   }
 }
 
 export async function updateLoadStatus(id: string, status: string) {
   try {
     const { userId, orgId } = await auth();
-    
+
     if (!userId || !orgId) {
-      return { success: false, error: 'Unauthorized' };
+      return { success: false, error: "Unauthorized" };
     }
 
     const load = await db.load.update({
-      where: { 
+      where: {
         id,
         organizationId: orgId,
       },
       data: {
-        
         updatedAt: new Date(),
       },
     });
 
-    revalidatePath('/[orgId]/dispatch', 'page');
+    revalidatePath("/[orgId]/dispatch", "page");
     return { success: true, data: load };
   } catch (error) {
-    console.error('Error updating load status:', error);
-    return { success: false, error: 'Failed to update load status' };
+    console.error("Error updating load status:", error);
+    return { success: false, error: "Failed to update load status" };
   }
 }
 
 export async function deleteLoadAction(id: string) {
   try {
     const { userId, orgId } = await auth();
-    
+
     if (!userId || !orgId) {
-      return { success: false, error: 'Unauthorized' };
+      return { success: false, error: "Unauthorized" };
     }
 
     await db.load.delete({
-      where: { 
+      where: {
         id,
         organizationId: orgId,
       },
     });
 
-    revalidatePath('/[orgId]/dispatch', 'page');
+    revalidatePath("/[orgId]/dispatch", "page");
     return { success: true };
   } catch (error) {
-    console.error('Error deleting load:', error);
-    return { success: false, error: 'Failed to delete load' };
+    console.error("Error deleting load:", error);
+    return { success: false, error: "Failed to delete load" };
   }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded Tailwind colors with design tokens in dashboard widgets and auth error page
- expand `updateLoadAction` to persist all provided fields
- document the server action for Copilot context

## Testing
- `npm run build` *(fails: Type '{ params: { orgId: string; userId: string; }; }' does not satisfy the constraint 'PageProps')*

------
https://chatgpt.com/codex/tasks/task_e_6840cd806254832791a795ee0a75114a