### PR TITLE
Implement db-backed vehicle and user fetchers

### DIFF
--- a/lib/fetchers/userFetchers.ts
+++ b/lib/fetchers/userFetchers.ts
@@ -1,13 +1,48 @@
-import { UserRole } from "@/types/auth";
+"use server";
 
-// Define UserWithRole type as a placeholder. Adjust as needed.
-type UserWithRole = {
+import { auth } from "@clerk/nextjs/server";
+
+import prisma from "@/lib/database/db";
+import { type UserRole } from "@/types/auth";
+
+export type UserWithRole = {
   id: string;
   name: string;
   role: UserRole;
 };
 
+/**
+ * Retrieve all users for an organization along with their assigned roles.
+ */
 export async function listOrganizationUsers(orgId: string): Promise<UserWithRole[]> {
-  // ...fetch from Clerk and/or DB...
-  return [];
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
+
+  const requestingUser = await prisma.user.findUnique({
+    where: { clerkId: userId },
+    select: { organizationId: true },
+  });
+
+  if (!requestingUser || requestingUser.organizationId !== orgId) {
+    throw new Error("Access denied");
+  }
+
+  const memberships = await prisma.organizationMembership.findMany({
+    where: { organizationId: orgId },
+    include: {
+      user: {
+        select: { id: true, firstName: true, lastName: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  return memberships.map((m) => ({
+    id: m.user.id,
+    name: `${m.user.firstName ?? ""} ${m.user.lastName ?? ""}`.trim(),
+    role: m.role as UserRole,
+  }));
 }
+

--- a/lib/fetchers/vehicleFetchers.ts
+++ b/lib/fetchers/vehicleFetchers.ts
@@ -1,6 +1,117 @@
-import { Vehicle } from "@/types/vehicles";
+"use server";
 
-export async function listVehiclesByOrg(orgId: string, filters: any): Promise<Vehicle[]> {
-  // ...fetch vehicles from DB...
-  return [];
+import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
+
+import prisma from "@/lib/database/db";
+import { vehicleFilterSchema, type VehicleFiltersData } from "@/schemas/vehicles";
+import { type Vehicle } from "@/types/vehicles";
+
+/**
+ * List vehicles for an organization with optional filtering.
+ *
+ * Validates the filter input using {@link vehicleFilterSchema} before querying
+ * the database. The returned objects are mapped to the shared {@link Vehicle}
+ * type used throughout the application.
+ */
+export async function listVehiclesByOrg(
+  orgId: string,
+  filters: VehicleFiltersData = {} as VehicleFiltersData
+): Promise<Vehicle[]> {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Unauthorized");
+  }
+
+  const parsed = vehicleFilterSchema.parse(filters);
+
+  const where: any = { organizationId: orgId };
+
+  if (parsed.search) {
+    const term = parsed.search;
+    where.OR = [
+      { unitNumber: { contains: term, mode: "insensitive" } },
+      { vin: { contains: term, mode: "insensitive" } },
+      { make: { contains: term, mode: "insensitive" } },
+      { model: { contains: term, mode: "insensitive" } },
+      { licensePlate: { contains: term, mode: "insensitive" } },
+    ];
+  }
+
+  if (parsed.type) {
+    where.type = parsed.type;
+  }
+
+  if (parsed.status) {
+    where.status = parsed.status;
+  }
+
+  if (parsed.make) {
+    where.make = { contains: parsed.make, mode: "insensitive" };
+  }
+
+  if (parsed.model) {
+    where.model = { contains: parsed.model, mode: "insensitive" };
+  }
+
+  if (parsed.year) {
+    where.year = parsed.year;
+  }
+
+  if (parsed.maintenanceDue) {
+    where.nextInspectionDue = { lte: new Date() };
+  }
+
+  // Basic pagination
+  const page = parsed.page || 1;
+  const limit = parsed.limit || 10;
+
+  const results = await prisma.vehicle.findMany({
+    where,
+    orderBy: { unitNumber: "asc" },
+    include: {
+      organization: { select: { id: true, name: true } },
+    },
+    skip: (page - 1) * limit,
+    take: limit,
+  });
+
+  // Map Prisma result to public Vehicle type
+  const vehicles: Vehicle[] = results.map((v) => ({
+    id: v.id,
+    organizationId: v.organizationId,
+    type: v.type as Vehicle["type"],
+    status: v.status as Vehicle["status"],
+    make: v.make ?? "",
+    model: v.model ?? "",
+    year: v.year ?? 0,
+    vin: v.vin ?? "",
+    licensePlate: v.licensePlate ?? undefined,
+    unitNumber: v.unitNumber ?? undefined,
+    grossVehicleWeight: undefined,
+    maxPayload: undefined,
+    fuelType: v.fuelType ?? undefined,
+    engineType: undefined,
+    registrationNumber: undefined,
+    registrationExpiry: v.registrationExpiration ?? undefined,
+    insuranceProvider: undefined,
+    insurancePolicyNumber: undefined,
+    insuranceExpiry: v.insuranceExpiration ?? undefined,
+    currentDriverId: undefined,
+    currentLoadId: undefined,
+    currentLocation: undefined,
+    totalMileage: v.currentOdometer ?? undefined,
+    lastMaintenanceMileage: undefined,
+    nextMaintenanceDate: v.nextInspectionDue ?? undefined,
+    nextMaintenanceMileage: undefined,
+    createdAt: v.createdAt,
+    updatedAt: v.updatedAt,
+    driver: undefined,
+    organization: v.organization
+      ? { id: v.organization.id, name: v.organization.name }
+      : undefined,
+  }));
+
+  return vehicles;
 }
+


### PR DESCRIPTION
## Summary
- implement `listVehiclesByOrg` with Prisma queries and filtering
- implement `listOrganizationUsers` to load org members and roles

## Testing
- `npx tsc -p tsconfig.json` *(fails: Argument of type '{}' is not assignable ...)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0f403248327956939260719e4ca