### PR TITLE
Implement vehicle list page

### DIFF
--- a/components/vehicles/vehicle-table.tsx
+++ b/components/vehicles/vehicle-table.tsx
@@ -1,0 +1,44 @@
+import { Vehicle } from "@/types/vehicles";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface VehicleTableProps {
+  vehicles: Vehicle[];
+}
+
+export function VehicleTable({ vehicles }: VehicleTableProps) {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-b bg-muted/50">
+            <TableHead>Unit #</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Make</TableHead>
+            <TableHead>Model</TableHead>
+            <TableHead>Year</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {vehicles.map((v) => (
+            <TableRow key={v.id} className="border-b">
+              <TableCell className="font-medium">{v.unitNumber}</TableCell>
+              <TableCell>{v.type}</TableCell>
+              <TableCell>{v.make}</TableCell>
+              <TableCell>{v.model}</TableCell>
+              <TableCell>{v.year}</TableCell>
+              <TableCell>{v.status}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/features/vehicles/VehicleListPage.tsx
+++ b/features/vehicles/VehicleListPage.tsx
@@ -1,8 +1,34 @@
-import { listVehiclesByOrg } from "@/lib/fetchers/vehicleFetchers";
-import { VehicleForm } from "@/components/vehicles/VehicleForm";
+import Link from "next/link";
 
-export default async function VehicleListPage({ orgId }: { orgId: string }) {
-  const vehicles = await listVehiclesByOrg(orgId, {});
-  // ...render vehicle list and form...
-  return <div>{/* ...vehicle list... */}</div>;
+import { listVehiclesByOrg } from "@/lib/fetchers/vehicleFetchers";
+import { VehicleTable } from "@/components/vehicles/vehicle-table";
+
+interface VehicleListPageProps {
+  orgId: string;
+  page?: number;
+}
+
+export default async function VehicleListPage({ orgId, page = 1 }: VehicleListPageProps) {
+  const { vehicles, totalPages } = await listVehiclesByOrg(orgId, { page });
+
+  return (
+    <div className="space-y-4">
+      <VehicleTable vehicles={vehicles} />
+      <div className="flex items-center justify-between">
+        <Link
+          href={`?page=${page - 1}`}
+          className={`btn btn-outline ${page <= 1 ? "pointer-events-none opacity-50" : ""}`}
+        >
+          Previous
+        </Link>
+        <span className="text-sm">Page {page} of {totalPages}</span>
+        <Link
+          href={`?page=${page + 1}`}
+          className={`btn btn-outline ${page >= totalPages ? "pointer-events-none opacity-50" : ""}`}
+        >
+          Next
+        </Link>
+      </div>
+    </div>
+  );
 }

--- a/lib/fetchers/vehicleFetchers.ts
+++ b/lib/fetchers/vehicleFetchers.ts
@@ -1,6 +1,99 @@
-import { Vehicle } from "@/types/vehicles";
+"use server";
 
-export async function listVehiclesByOrg(orgId: string, filters: any): Promise<Vehicle[]> {
-  // ...fetch vehicles from DB...
-  return [];
-}
+import { auth } from "@clerk/nextjs/server";
+import { cache } from "react";
+
+import prisma from "@/lib/database/db";
+import type { Vehicle, VehicleFilters, VehicleListResponse } from "@/types/vehicles";
+
+/**
+ * List vehicles for an organization with optional filtering and pagination
+ */
+export const listVehiclesByOrg = cache(async (
+  orgId: string,
+  filters: VehicleFilters = {}
+): Promise<VehicleListResponse> => {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return { vehicles: [], total: 0, page: 1, limit: 10, totalPages: 0 };
+    }
+
+    const where: any = { organizationId: orgId };
+
+    if (filters.search) {
+      const search = filters.search;
+      where.OR = [
+        { unitNumber: { contains: search, mode: "insensitive" } },
+        { make: { contains: search, mode: "insensitive" } },
+        { model: { contains: search, mode: "insensitive" } },
+        { vin: { contains: search, mode: "insensitive" } },
+        { licensePlate: { contains: search, mode: "insensitive" } },
+      ];
+    }
+
+    if (filters.type) {
+      where.type = filters.type;
+    }
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    if (filters.make) {
+      where.make = { contains: filters.make, mode: "insensitive" };
+    }
+
+    if (filters.model) {
+      where.model = { contains: filters.model, mode: "insensitive" };
+    }
+
+    if (filters.year) {
+      where.year = filters.year;
+    }
+
+    if (filters.assignedDriverId) {
+      where.currentDriverId = filters.assignedDriverId;
+    }
+
+    if (filters.maintenanceDue) {
+      where.nextMaintenanceDate = { lte: new Date() };
+    }
+
+    const page = filters.page || 1;
+    const limit = Math.min(filters.limit || 10, 100);
+    const skip = (page - 1) * limit;
+
+    const [vehicles, total] = await Promise.all([
+      prisma.vehicle.findMany({
+        where,
+        include: {
+          driver: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+          organization: { select: { id: true, name: true } },
+        },
+        orderBy: { unitNumber: "asc" },
+        skip,
+        take: limit,
+      }),
+      prisma.vehicle.count({ where }),
+    ]);
+
+    return {
+      vehicles,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  } catch (error) {
+    console.error("Error listing vehicles:", error);
+    return { vehicles: [], total: 0, page: 1, limit: 10, totalPages: 0 };
+  }
+});
+

--- a/types/vehicles.ts
+++ b/types/vehicles.ts
@@ -95,6 +95,14 @@ export interface VehicleFilters {
   limit?: number;
 }
 
+export interface VehicleListResponse {
+  vehicles: Vehicle[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 export interface VehicleMaintenanceRecord {
   id: string;
   vehicleId: string;


### PR DESCRIPTION
## Summary
- implement `VehicleListResponse` type
- add real DB-backed `listVehiclesByOrg` fetcher with pagination
- render vehicles in `VehicleListPage` with navigation controls
- create reusable `VehicleTable` component for table display

## Testing
- `npm run build` *(fails: Type error in loadActions.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6840e0f0785c8327bb3f3d3478e64f33